### PR TITLE
add "try online" link to compiler explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Compiler explorer](https://img.shields.io/badge/compiler_explorer-online-blue.svg)](https://godbolt.org/z/EnYz8z)
+
 # metastring
 
 This mini library provides interfaces for converting strings to types and working with those types at compile time.


### PR DESCRIPTION
Thanks.

In case you want to update the version of your lib in Compiler explorer, you need a raw permalink to you file, your file can only include standard headers.
Select the your file metastring.hpp, press the key y (your url should show now the hash), refresh with F5 and than klick on the raw button.